### PR TITLE
fix:(ansible) update model download logic

### DIFF
--- a/edge_auto_jetson_launch/launch/tensorrt_yolox.launch.xml
+++ b/edge_auto_jetson_launch/launch/tensorrt_yolox.launch.xml
@@ -4,9 +4,9 @@
   <!-- output topic name to be published (bbox) -->
   <arg name="output/objects" default="/perception/object_recognition/detection/rois0" />
   <!-- path to the YOLOX model to be loaded -->
-  <arg name="model_path" default="$(find-pkg-share tensorrt_yolox)/data/yolox-tiny.onnx" />
+  <arg name="model_path" default="/opt/autoware/data/tensorrt_yolox/yolox-tiny.onnx" />
   <!-- path to the label file to explain category ID and string -->
-  <arg name="label_path" default="$(find-pkg-share tensorrt_yolox)/data/label.txt" />
+  <arg name="label_path" default="/opt/autoware/data/tensorrt_yolox/label.txt" />
   <!-- container naem that this ROS node to be loaded -->
   <arg name="container_name" default="" />
   <!-- flag to use ROS2 intra process -->


### PR DESCRIPTION
## PR Type
- Bug Fix

## Related Links
- https://github.com/autowarefoundation/autoware.universe/issues/3137
- https://github.com/tier4/edge-auto/pull/17
- https://github.com/tier4/edge-auto-jetson/pull/41
- https://github.com/tier4/edge_auto_launch/pull/15

## Description

This PR fixes edge-auto to align with Autoware Universe's new model download logic.

## Tests performed

Centerpoint and YOLOX from edge-auto and edge-auto-jetson respectively, were launched, and I confirmed that they were outputting predictions at the correct frequency (~10 Hz).

## Effects on system behavior

Previously, edge-auto's model downloading was broken by an update to Autoware Universe, such that YOLOX and Centerpoint would not be able to launch. This PR updates edge-auto to correctly download models under Autoware Universe's new scheme.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
