### PR TITLE
launcher. fix launcher to the autoware 2024.07 version

### DIFF
--- a/edge_auto_jetson_launch/config/bytetrack.param.yaml
+++ b/edge_auto_jetson_launch/config/bytetrack.param.yaml
@@ -1,0 +1,3 @@
+/**:
+  ros__parameters:
+    track_buffer_length: 30

--- a/edge_auto_jetson_launch/config/bytetrack_visualizer.param.yaml
+++ b/edge_auto_jetson_launch/config/bytetrack_visualizer.param.yaml
@@ -1,0 +1,3 @@
+/**:
+  ros__parameters:
+    use_raw: true

--- a/edge_auto_jetson_launch/config/yolox_tiny.param.yaml
+++ b/edge_auto_jetson_launch/config/yolox_tiny.param.yaml
@@ -1,0 +1,39 @@
+# cspell:ignore semseg
+/**:
+  ros__parameters:
+
+    # refine segmentation mask by overlay roi class
+    # disable when sematic segmentation accuracy is good enough
+    is_roi_overlap_segment: true
+
+    # minimum existence_probability of detected roi considered to replace segmentation
+    overlap_roi_score_threshold: 0.3
+
+    # publish color mask for result visualization
+    is_publish_color_mask: false
+
+    roi_overlay_segment_label:
+      UNKNOWN : true
+      CAR : false
+      TRUCK : false
+      BUS : false
+      MOTORCYCLE : true
+      BICYCLE : true
+      PEDESTRIAN : true
+      ANIMAL: true
+
+    model_path: "$(var data_path)/tensorrt_yolox/$(var model_name).onnx" # The onnx file name for YOLOX model.
+    label_path: "$(var data_path)/tensorrt_yolox/label.txt" # The label file path for YOLOX model.
+    color_map_path: "$(var data_path)/tensorrt_yolox/semseg_color_map.csv"
+    score_threshold: 0.35 # Objects with a score lower than this value will be ignored. This threshold will be ignored if specified model contains EfficientNMS_TRT module in it.
+    nms_threshold: 0.7 # Detection results will be ignored if IoU over this value. This threshold will be ignored if specified model contains EfficientNMS_TRT module in it.
+
+    precision: "fp16" # Operation precision to be used on inference. Valid value is one of: [fp32, fp16, int8].
+    calibration_algorithm: "MinMax" # Calibration algorithm to be used for quantization when precision==int8. Valid value is one of: [Entropy, (Legacy | Percentile), MinMax].
+    dla_core_id: -1 # If positive ID value is specified, the node assign inference task to the DLA core.
+    quantize_first_layer: false # If true, set the operating precision for the first (input) layer to be fp16. This option is valid only when precision==int8.
+    quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
+    profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
+    clip_value: 0.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
+    preprocess_on_gpu: true # If true, pre-processing is performed on GPU.
+    calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.

--- a/edge_auto_jetson_launch/launch/bytetrack.launch.xml
+++ b/edge_auto_jetson_launch/launch/bytetrack.launch.xml
@@ -1,60 +1,25 @@
 <launch>
-  <!-- input topic name to be subscribed (bbox) -->
-  <arg name="input/objects" default="/perception/object_recognition/detection/rois0" />
-  <!-- input topic name to be subscribed (image for visualizer) -->
-  <arg name="input/image" default="image_raw" />
-  <!-- flag to describe whether input topic is raw or compressed  -->
-  <arg name="input/image/is_raw" default="True" />
-  <!-- output topic name to be published (bbox) -->
-  <arg name="output/objects" default="/perception/object_recognition/detection/tracked/rois0" />
-  <!-- container naem that this ROS node to be loaded -->
-  <arg name="container_name" default="" />
-  <!-- flag to use ROS2 intra process -->
-  <arg name="use_intra_process" default="True" />
-  <!-- flag to enable bytetrack visualization -->
-  <arg name="enable_bytetrack_visualizer" default="True" />
+  <arg name="input/image" default="/sensing/camera/camera0/image_rect_color"/>
+  <arg name="in_image_compressed" default="$(var input/image)/compressed"/>
+  <arg name="input/objects" default="/perception/object_recognition/detection/rois0"/>
+  <arg name="output/objects" default="/perception/object_recognition/detection/tracked/rois0"/>
+  <arg name="bytetrack_param_path" default="$(find-pkg-share edge_auto_jetson_launch)/config/bytetrack.param.yaml"/>
+  <arg name="bytetrack_visualizer_param_path" default="$(find-pkg-share edge_auto_jetson_launch)/config/bytetrack_visualizer.param.yaml"/>
+  <arg name="enable_visualizer" default="true"/>
+  <arg name="camera_id" default="0" />
 
-  <!-- algorithm parameters -->
-  <arg name="track_buffer_length" default="30"
-       description="The frame count length that a tracklet is considered to be valid" />
+  <node pkg="autoware_bytetrack" exec="bytetrack_node_exe" output="screen" name="bytetrack_node_exe_$(var camera_id)">
+    <remap from="~/in/rect" to="$(var input/objects)"/>
+    <remap from="~/out/objects" to="$(var output/objects)"/>
+    <remap from="~/out/objects/debug/uuid" to="$(var output/objects)/debug/uuid"/>
+    <param from="$(var bytetrack_param_path)"/>
+  </node>
 
-  <let name="empty_container_is_specified" value="$(eval 'not &quot;$(var container_name)&quot;')" />
-  <!-- If container name is not specified,
-       execute function as an individual node  -->
-  <group if="$(var empty_container_is_specified)">
-    <node pkg="bytetrack" exec="bytetrack_node_exe" name="bytetrack">
-      <remap from="~/in/rect" to="$(var input/objects)"/>
-      <remap from="~/out/objects" to="$(var output/objects)"/>
-      <remap from="~/out/objects/debug/uuid" to="$(var output/objects)/debug/uuid"/>
-      <param name="track_buffer_length" value="$(var track_buffer_length)"/>
-    </node>
-  </group>
-
-  <!-- If container name is specified,
-       execute function as a composable node and load it into the container  -->
-  <group unless="$(var empty_container_is_specified)">
-    <load_composable_node target="$(var container_name)">
-      <composable_node pkg="bytetrack" plugin="bytetrack::ByteTrackNode" name="bytetrack">
-        <remap from="~/in/rect" to="$(var input/objects)"/>
-        <remap from="~/out/objects" to="$(var output/objects)"/>
-        <remap from="~/out/objects/debug/uuid" to="$(var output/objects)/debug/uuid"/>
-        <param name="track_buffer_length" value="$(var track_buffer_length)"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-      </composable_node>
-    </load_composable_node>
-  </group>
-
-  <!-- Execute visualizer as a separated node -->
-  <node pkg="bytetrack" exec="bytetrack_visualizer_node_exe"
-        name="bytetrack_visualizer" if="$(var enable_bytetrack_visualizer)">
-    <remap from="~/in/image" to="$(var input/image)" />
-    <remap from="~/in/rect" to="$(var output/objects)" />
-    <remap from="~/in/uuid" to="$(var output/objects)/debug/uuid" />
-    <remap from="~/out/image" to="$(var output/objects)/debug/image" />
-    <remap from="~/out/image/compressed" to="$(var output/objects)/debug/image/compressed" />
-    <remap from="~/out/image/compressedDepth" to="$(var output/objects)/debug/image/compressedDepth" />
-    <remap from="~/out/image/theora" to="$(var output/objects)/debug/image/theora" />
-    <param name="use_raw" value="$(var input/image/is_raw)" />
+  <node pkg="autoware_bytetrack" exec="bytetrack_visualizer_node_exe" output="screen" if="$(var enable_visualizer)" name="bytetrack_visualizer_node_exe_$(var camera_id)">
+    <remap from="~/in/image" to="$(var input/image)"/>
+    <remap from="~/in/rect" to="$(var output/objects)"/>
+    <remap from="~/in/uuid" to="$(var output/objects)/debug/uuid"/>
+    <param from="$(var bytetrack_visualizer_param_path)"/>
   </node>
 
 </launch>

--- a/edge_auto_jetson_launch/launch/perception_jetson0.launch.xml
+++ b/edge_auto_jetson_launch/launch/perception_jetson0.launch.xml
@@ -44,6 +44,7 @@
         <arg name="container_name" value="$(var container_name)" />
         <arg name="input/image" value="/sensing/camera/$(var camera_name)/image_raw" />
         <arg name="output/objects" value="tensorrt_yolox/rois$(var camera_id)" />
+        <arg name="camera_id" value="$(var camera_id)" />
       </include>
 
       <include file="$(find-pkg-share edge_auto_jetson_launch)/launch/bytetrack.launch.xml">
@@ -52,6 +53,7 @@
         <arg name="input/image" value="/sensing/camera/$(var camera_name)/image_raw" />
         <arg name="input/image/is_raw" value="True" />
         <arg name="output/objects" value="/perception/object_recognition/detection/rois$(var camera_id)" />
+        <arg name="camera_id" value="$(var camera_id)" />
       </include>
     </group>
   </group>  <!-- camera0  -->
@@ -95,12 +97,14 @@
       <push-ros-namespace namespace="perception/object_recognition/detection" />
       <include file="$(find-pkg-share edge_auto_jetson_launch)/launch/tensorrt_yolox.launch.xml">
         <arg name="container_name" value="$(var container_name)" />
+        <arg name="camera_id" value="$(var camera_id)" />
         <arg name="input/image" value="/sensing/camera/$(var camera_name)/image_raw" />
         <arg name="output/objects" value="tensorrt_yolox/rois$(var camera_id)" />
       </include>
 
       <include file="$(find-pkg-share edge_auto_jetson_launch)/launch/bytetrack.launch.xml">
         <arg name="container_name" value="$(var container_name)" />
+        <arg name="camera_id" value="$(var camera_id)" />
         <arg name="input/objects" value="tensorrt_yolox/rois$(var camera_id)" />
         <arg name="input/image" value="/sensing/camera/$(var camera_name)/image_raw" />
         <arg name="input/image/is_raw" value="True" />

--- a/edge_auto_jetson_launch/launch/tensorrt_yolox.launch.xml
+++ b/edge_auto_jetson_launch/launch/tensorrt_yolox.launch.xml
@@ -1,93 +1,19 @@
 <launch>
   <!-- image topic name to be subscribed -->
-  <arg name="input/image" default="image_raw" />
-  <!-- output topic name to be published (bbox) -->
-  <arg name="output/objects" default="/perception/object_recognition/detection/rois0" />
-  <!-- path to the YOLOX model to be loaded -->
-  <arg name="model_path" default="$(find-pkg-share tensorrt_yolox)/data/yolox-tiny.onnx" />
-  <!-- path to the label file to explain category ID and string -->
-  <arg name="label_path" default="$(find-pkg-share tensorrt_yolox)/data/label.txt" />
-  <!-- container naem that this ROS node to be loaded -->
-  <arg name="container_name" default="" />
-  <!-- flag to use ROS2 intra process -->
-  <arg name="use_intra_process" default="True" />
-
-  <!-- algorithm parameters -->
-  <arg name="score_threshold" default="0.35" />
-  <arg name="nms_threshold" default="0.7" />
-  <arg name="precision" default="fp32"
-       description="operation precision to be used on inference.Valid value is one of: [fp32, fp16, int8]" />
-  <arg name="calibration_algorithm"
-       default="MinMax"
-       description="Calibration algorithm to be used for quantization when precision==int8. Valid value is one of: [Entropy, (Legacy | Percentile), MinMax]" />
-  <arg name="dla_core_id" default="-1"
-       description="If positive ID value is specified, the node assign inference task to the DLA core" />
-  <arg name="quantize_first_layer" default="false"
-       description="If true, set the operating precision for the first (input) layer to be fp16. This option is valid only when precision==int8" />
-  <arg name="quantize_last_layer" default="false"
-       description="If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8" />
-  <arg name="profile_per_layer" default="false"
-       description="If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose." />
-  <arg name="clip_value" default="0.0"
-       description="If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration." />
-  <arg name="preprocess_on_gpu" default="true" description="If true, pre-processing is performed on GPU" />
-  <arg name="calibration_image_list_path" default=""
-       description="Path to a file which contains path to images. Those images will be used for int8 quantization." />
-
-  <let name="empty_container_is_specified" value="$(eval 'not &quot;$(var container_name)&quot;')" />
-  <!-- If container name is not specified,
-       execute function as an individual node  -->
-  <group if="$(var empty_container_is_specified)">
-      <node pkg="tensorrt_yolox" exec="tensorrt_yolox_node_exe" name="tensorrt_yolox">
-        <remap from="~/in/image" to="$(var input/image)" />
-        <remap from="~/out/objects" to="$(var output/objects)" />
-        <remap from="~/out/image" to="$(var output/objects)/debug/image" />
-        <remap from="~/out/image/compressed" to="$(var output/objects)/debug/image/compressed" />
-        <remap from="~/out/image/compressedDepth" to="$(var output/objects)/debug/image/compressedDepth" />
-        <remap from="~/out/image/theora" to="$(var output/objects)/debug/image/theora" />
-        <param name="score_threshold" value="$(var score_threshold)" />
-        <param name="nms_threshold" value="$(var nms_threshold)" />
-        <param name="model_path" value="$(var model_path)" />
-        <param name="label_path" value="$(var label_path)" />
-        <param name="precision" value="$(var precision)" />
-        <param name="calibration_algorithm" value="$(var calibration_algorithm)" />
-        <param name="dla_core_id" value="$(var dla_core_id)" />
-        <param name="quantize_first_layer" value="$(var quantize_first_layer)" />
-        <param name="quantize_last_layer" value="$(var quantize_last_layer)" />
-        <param name="profile_per_layer" value="$(var profile_per_layer)" />
-        <param name="clip_value" value="$(var clip_value)" />
-        <param name="preprocess_on_gpu" value="$(var preprocess_on_gpu)" />
-        <param name="calibration_image_list_path" value="$(var calibration_image_list_path)" />
-      </node>
-  </group>
-
-  <!-- If container name is specified,
-       execute function as a composable node and load it into the container  -->
-  <group unless="$(var empty_container_is_specified)">
-    <load_composable_node target="$(var container_name)">
-      <composable_node pkg="tensorrt_yolox" plugin="tensorrt_yolox::TrtYoloXNode" name="tensorrt_yolox">
-        <remap from="~/in/image" to="$(var input/image)" />
-        <remap from="~/out/objects" to="$(var output/objects)" />
-        <remap from="~/out/image" to="$(var output/objects)/debug/image" />
-        <remap from="~/out/image/compressed" to="$(var output/objects)/debug/image/compressed" />
-        <remap from="~/out/image/compressedDepth" to="$(var output/objects)/debug/image/compressedDepth" />
-        <remap from="~/out/image/theora" to="$(var output/objects)/debug/image/theora" />
-        <param name="score_threshold" value="$(var score_threshold)" />
-        <param name="nms_threshold" value="$(var nms_threshold)" />
-        <param name="model_path" value="$(var model_path)" />
-        <param name="label_path" value="$(var label_path)" />
-        <param name="precision" value="$(var precision)" />
-        <param name="calibration_algorithm" value="$(var calibration_algorithm)" />
-        <param name="dla_core_id" value="$(var dla_core_id)" />
-        <param name="quantize_first_layer" value="$(var quantize_first_layer)" />
-        <param name="quantize_last_layer" value="$(var quantize_last_layer)" />
-        <param name="profile_per_layer" value="$(var profile_per_layer)" />
-        <param name="clip_value" value="$(var clip_value)" />
-        <param name="preprocess_on_gpu" value="$(var preprocess_on_gpu)" />
-        <param name="calibration_image_list_path" value="$(var calibration_image_list_path)" />
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)" />
-      </composable_node>
-    </load_composable_node>
-  </group>
+  <arg name="input/image" default="image_raw"/>
+  <arg name="output/objects" default="/perception/object_recognition/detection/rois0"/>
+  <arg name="model_name" default="yolox-sPlus-opt"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="yolox_param_path" default="$(find-pkg-share edge_auto_jetson_launch)/config/yolox_tiny.param.yaml"/>
+  <arg name="use_decompress" default="true" description="use image decompress"/>
+  <arg name="build_only" default="false" description="exit after trt engine is built"/>
+  <arg name="camera_id" default="0" />
+  
+  <node pkg="autoware_tensorrt_yolox" exec="autoware_tensorrt_yolox_node_exe" name="tensorrt_yolox_$(var camera_id)" output="screen">
+    <remap from="~/in/image" to="$(var input/image)"/>
+    <remap from="~/out/objects" to="$(var output/objects)"/>
+    <param from="$(var yolox_param_path)" allow_substs="true"/>
+    <param name="build_only" value="$(var build_only)"/>
+  </node>
 
 </launch>


### PR DESCRIPTION
## PR Type

- Bug Fix

## Description

This PR adapts edge_auto_jetson launcher to the autoware universe version 2024.07 for the ROSCUBE RQX-58g. 
This PR requires the PR https://github.com/tier4/edge-auto-jetson/pull/57 to setup the ROSCUBE.

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [X] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
