### PR TITLE
chore(jetson_launch): integrate lidar pipeline execution on edge device

### DIFF
--- a/edge_auto_jetson_launch/config/centerpoint_tiny.param.yaml
+++ b/edge_auto_jetson_launch/config/centerpoint_tiny.param.yaml
@@ -1,0 +1,19 @@
+/**:
+  ros__parameters:
+    # weight files
+    encoder_onnx_path: "$(var model_path)/pts_voxel_encoder_$(var model_name).onnx"
+    encoder_engine_path: "$(var model_path)/pts_voxel_encoder_$(var model_name).engine"
+    head_onnx_path: "$(var model_path)/pts_backbone_neck_head_$(var model_name).onnx"
+    head_engine_path: "$(var model_path)/pts_backbone_neck_head_$(var model_name).engine"
+    trt_precision: fp16
+    cloud_capacity: 2000000
+    post_process_params:
+      # post-process params
+      circle_nms_dist_threshold: 0.5
+      iou_nms_search_distance_2d: 10.0
+      iou_nms_threshold: 0.1
+      score_threshold: 0.35
+      yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
+    densification_params:
+      world_frame_id: base_link
+      num_past_frames: 1

--- a/edge_auto_jetson_launch/config/yolox.param.yaml
+++ b/edge_auto_jetson_launch/config/yolox.param.yaml
@@ -36,4 +36,5 @@
     profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
     clip_value: 0.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
     preprocess_on_gpu: true # If true, pre-processing is performed on GPU.
+    gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.

--- a/edge_auto_jetson_launch/launch/perception_jetson0.launch.xml
+++ b/edge_auto_jetson_launch/launch/perception_jetson0.launch.xml
@@ -2,6 +2,15 @@
   <arg name="vehicle_id" />
   <arg name="live_sensor" default="True"/>
   <arg name="perception" default="True"/>
+  <arg name="sensor_height" default="1.0"/>
+  <arg name="lidar_detection_model_type" description="options: `centerpoint`, `apollo`"/>
+
+  <arg name="voxel_grid_downsample_filter_size_x" default="0.3" />
+  <arg name="voxel_grid_downsample_filter_size_y" default="0.3" />
+  <arg name="voxel_grid_downsample_filter_size_z" default="0.1" />
+
+  <!-- base_link generation -->
+  <node pkg="tf2_ros" exec="static_transform_publisher" name="base_link_broadcaster" output="screen" args="--x 0.0 --y 0.0 --z $(var sensor_height) --qx 0.0 --qy 0.0 --qz 0.0 --qw 1.2 --frame-id base_link --child-frame-id hesai" />
 
   <!-- camera0 -->
   <group>
@@ -112,5 +121,125 @@
       </include>
     </group>
   </group>  <!-- camera1  -->
+
+  <!-- lidar -->
+  <!-- driver -->
+  <group>
+    <push-ros-namespace namespace="/sensing/lidar/"/>
+    <include file="$(find-pkg-share nebula_ros)/launch/hesai_launch_all_hw.xml">
+      <arg name="sensor_model" value="PandarQT128"/>
+    </include>
+  </group> <!-- driver -->
+  
+  <!-- perception -->
+  <group>
+    <push-ros-namespace namespace="/perception"/>
+    <group>
+      <include file="$(find-pkg-share edge_auto_launch)/launch/component/crop_box_filter.launch.xml">
+        <arg name="input/pointcloud" value="/sensing/lidar/pandar_points"/>
+        <arg name="output/pointcloud" value="cropped/pointcloud"/>
+        <arg name="frame_id" value="base_link"/>
+        <arg name="max_z" value="2.0"/>
+      </include>
+      <push-ros-namespace namespace="obstacle_segmentation"/>
+      <include file="$(find-pkg-share autoware_ground_segmentation)/launch/ray_ground_filter.launch.xml">
+        <arg name="input/pointcloud" value="/perception/cropped/pointcloud"/>
+        <arg name="output/pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>
+      </include>
+    </group>
+
+    <group if="$(eval &quot;'$(var lidar_detection_model_type)'=='centerpoint'&quot;)">
+      <push-ros-namespace namespace="centerpoint"/>
+      <arg name="lidar_model_param_path" default="$(find-pkg-share autoware_lidar_centerpoint)/config"/>
+
+      <group>
+        <node pkg="autoware_pointcloud_preprocessor" exec="voxel_grid_downsample_filter_node" name="voxel_grid_downsample_filter_node">
+          <remap from="input" to="/sensing/lidar/pandar_points" />
+            <remap from="output" to="downsample/pointcloud" />
+            <param name="voxel_size_x" value="$(var voxel_grid_downsample_filter_size_x)" />
+            <param name="voxel_size_y" value="$(var voxel_grid_downsample_filter_size_y)" />
+            <param name="voxel_size_z" value="$(var voxel_grid_downsample_filter_size_z)" />
+        </node>
+
+        <include file="$(find-pkg-share autoware_lidar_centerpoint)/launch/lidar_centerpoint.launch.xml">
+          <arg name="input/pointcloud" value="downsample/pointcloud"/>
+          <arg name="output/objects" value="objects"/>
+          <arg name="model_param_path" value="$(find-pkg-share edge_auto_jetson_launch)/config/centerpoint_tiny.param.yaml"/>
+          <arg name="use_pointcloud_container" value="false"/>
+        </include>
+      </group>
+    </group>
+
+    <group if="$(eval &quot;'$(var lidar_detection_model_type)'=='apollo'&quot;)">
+      <push-ros-namespace namespace="apollo"/>
+      <group>
+        <include file="$(find-pkg-share autoware_lidar_apollo_instance_segmentation)/launch/lidar_apollo_instance_segmentation.launch.xml">
+          <arg name="input/pointcloud" value="/sensing/lidar/pandar_points"/>
+          <arg name="output/objects" value="labeled_clusters"/>
+        </include>
+      </group>
+
+      <group>
+        <include file="$(find-pkg-share autoware_shape_estimation)/launch/shape_estimation.launch.xml">
+          <arg name="input/objects" value="labeled_clusters"/>
+          <arg name="output/objects" value="objects_with_feature"/>
+          <arg name="use_vehicle_reference_yaw" value="true"/>
+          <arg name="use_vehicle_reference_shape_size" value="false"/>
+        </include>
+      </group>
+
+      <group>
+        <include file="$(find-pkg-share autoware_detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
+          <arg name="input" value="objects_with_feature"/>
+          <arg name="output" value="objects"/>
+        </include>
+      </group>
+    </group>
+
+    <group>
+      <push-ros-namespace namespace="object_recognition/detection"/>
+      <group>
+        <push-ros-namespace namespace="euclidean_cluster"/>
+        <include file="$(find-pkg-share edge_auto_launch)/launch/component/voxel_grid_based_euclidean_cluster.launch.xml">
+          <arg name="input/pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>
+          <arg name="output/objects" value="clusters"/>
+        </include>
+        <include file="$(find-pkg-share autoware_shape_estimation)/launch/shape_estimation.launch.xml">
+          <arg name="input/objects" value="clusters"/>
+          <arg name="output/objects" value="objects_with_feature"/>
+          <arg name="node_name" value="shape_estimation"/>
+        </include>
+        <include file="$(find-pkg-share autoware_detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
+          <arg name="input" value="objects_with_feature"/>
+          <arg name="output" value="/perception/object_recognition/detection/euclidean_cluster/objects"/>
+          <arg name="node_name" value="detected_object_feature_remover"/>
+        </include>
+      </group>
+    </group>
+    <group>
+      <push-ros-namespace namespace="image_projection_based_fusion"/>
+      <include file="$(find-pkg-share edge_auto_launch)/launch/component/roi_cluster_fusion.launch.xml">
+        <arg name="input/clusters" value="/perception/object_recognition/detection/euclidean_cluster/clusters"/>
+        <arg name="output/clusters" value="clusters"/>
+        <arg name="input/rois_number" value="2"/>
+        <arg name="input/rois0" value="/perception/object_recognition/detection/rois0"/>
+        <arg name="input/camera_info0" value="/sensing/camera/camera0/camera_info"/>
+        <arg name="input/rois1" value="/perception/object_recognition/detection/rois1"/>
+        <arg name="input/camera_info1" value="/sensing/camera/camera1/camera_info"/>
+      </include>
+      <include file="$(find-pkg-share autoware_shape_estimation)/launch/shape_estimation.launch.xml">
+        <arg name="input/objects" value="clusters"/>
+        <arg name="output/objects" value="objects_with_feature"/>
+        <arg name="node_name" value="shape_estimation"/>
+      </include>
+      <include file="$(find-pkg-share autoware_detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
+        <arg name="input" value="objects_with_feature"/>
+        <arg name="output" value="/perception/object_recognition/detection/objects"/>
+        <arg name="node_name" value="detected_object_feature_remover"/>
+      </include>
+    </group>
+    
+  </group> 
+   <!-- perception -->
 
 </launch>


### PR DESCRIPTION
## PR Type

- Improvement

## Related Links

https://github.com/tier4/edge-auto-jetson/commit/495bbfae93034a7ff9a0e9c0c8b6597ceeb65e5c

## Description

This PR adds the LiDAR perception pipeline to the edge auto on the connected tech anvil platform when running on L4T-R36.4.0.


## Review Procedure

* Connect a lidar to the anvil, verify the lidar's IP address, destination IP, and port matches the configuration on ansible given by the main repository: https://github.com/tier4/edge-auto-jetson/blob/main/ansible/setup.yaml
* This PR assumes a QT128 sensor. Please change the lidar model to match your testing scenario.

## Pre-Review Checklist for the PR Author

- [ ] Assign PR to reviewer

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
